### PR TITLE
Refactor veth setup

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -237,7 +237,7 @@ func (p *Plugin) monitorContainerEvents() {
 
 // handleContainerEvent processes container lifecycle events
 func (p *Plugin) handleContainerEvent(event events.Message) {
-	containerID := event.ID
+	containerID := event.Actor.ID
 	action := event.Action
 
 	log.WithFields(log.Fields{
@@ -322,7 +322,7 @@ func (p *Plugin) performPeriodicCleanup() {
 
 	staleManagers := make([]string, 0)
 	staleInitialClients := make([]string, 0)
-	
+
 	// Check each DHCP manager for staleness
 	for endpointID, manager := range p.persistentDHCP {
 		if p.isManagerStale(manager) {
@@ -371,9 +371,9 @@ func (p *Plugin) performPeriodicCleanup() {
 	totalCleaned := len(staleManagers) + len(staleInitialClients)
 	if totalCleaned > 0 {
 		log.WithFields(log.Fields{
-			"managers": len(staleManagers),
+			"managers":        len(staleManagers),
 			"initial_clients": len(staleInitialClients),
-			"total": totalCleaned,
+			"total":           totalCleaned,
 		}).Info("Cleaned up stale DHCP resources")
 	}
 }


### PR DESCRIPTION
This PR does some minor cleanup and refactoring, after we saw issues with containers using different MAC addresses between DHCP setup and lease renewal.

I'm still not convinced that this PR fully resolves the problem, but I tested it with a few DHCP lease renewals (first by hard-coding a 5-minute timeout, then by using a real 1-hour DHCP lease duration from our router), and it _seems_ more reliable so far.

[This article](https://jvns.ca/blog/2017/09/03/debugging-netlink-requests/) was invaluable for debugging this! Once I was able to observe the bug through an `nlmon` device, I was then able to add some logs, and caught where it was happening on the Go side. As best as I can tell, some of the [rtnetlink](https://www.man7.org/linux/man-pages/man7/rtnetlink.7.html) operations seem to change the MAC address for one or both of the veth links for some reason...? Anyway, I reordered some of the `netlink` calls in the Go code-- based on the logs, I believe we now reliably get the MAC address only after it has potentially changed. I think the `netlink.SetHardwareAddr` call _should_ be unnecessary now... but I figured it shouldn't hurt to leave it in.

---

Oh, and I also made a few extra minor cleanups:

- Remove / rework some extra-verbose logs. I was mainly focused on the issues we were actually hitting, and so tried to trim out the stuff that didn't seem very helpful.
- Resolve some lint warnings (just small things that popped up in VS Code)